### PR TITLE
Improve open testing messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,24 @@
-# Astro Starter Kit: Minimal
+# JamBuddy Website
 
-```sh
-npm create astro@latest -- --template minimal
+This repository contains the marketing site for **JamBuddy**, a real-time chord detection app. The site is built with [Astro](https://astro.build/) and Tailwind CSS.
+
+JamBuddy is currently available via open testing on Google Play. Visit the site to join the program and give feedback as development continues.
+
+## Local Development
+
+```bash
+npm install
+npm run dev
 ```
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/minimal)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/minimal)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/minimal/devcontainer.json)
+The local server runs at `localhost:4321`.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Production Build
 
-## 🚀 Project Structure
+To generate the production site, run:
 
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
+```bash
+npm run build
 ```
 
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+The output is written to the `dist/` directory.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -195,9 +195,9 @@ import Layout from '../layouts/Layout.astro';
   <!-- CTA Section -->
   <section class="py-20 bg-black/80 rounded-lg mt-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">Try It Out</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">Join Open Testing</h2>
       <p class="text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
-        JamBuddy is a work in progress as I learn app development. I'd love for you to try it and let me know what you think!
+        JamBuddy is still in development. Join the Google Play open testing program and share your feedback!
       </p>
       <div class="flex flex-wrap gap-4 justify-center">
         <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-gray-800 border border-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-700 transition-colors flex items-center">

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -148,9 +148,7 @@ import Layout from '../layouts/Layout.astro';
               <div>
                 <h3 class="text-xl font-semibold text-gray-900 mb-1">Support</h3>
                 <p class="text-gray-600 mb-2">Technical help and troubleshooting</p>
-                <a href="mailto:sewing@warpandweftdata.com" class="text-green-600 hover:text-green-700 font-medium">
-                  sewing@warpandweftdata.com
-                </a>
+                <a href="mailto:sewing@warpandweftdata.com" class="text-green-600 hover:text-green-700 font-medium">Email us</a>
               </div>
             </div>
 
@@ -163,9 +161,7 @@ import Layout from '../layouts/Layout.astro';
               <div>
                 <h3 class="text-xl font-semibold text-gray-900 mb-1">Press & Media</h3>
                 <p class="text-gray-600 mb-2">Media inquiries and press kit</p>
-                <a href="mailto:sewing@warpandweftdata.com" class="text-purple-600 hover:text-purple-700 font-medium">
-                  sewing@warpandweftdata.com
-                </a>
+                <a href="mailto:sewing@warpandweftdata.com" class="text-purple-600 hover:text-purple-700 font-medium">Email us</a>
               </div>
             </div>
 
@@ -178,9 +174,7 @@ import Layout from '../layouts/Layout.astro';
               <div>
                 <h3 class="text-xl font-semibold text-gray-900 mb-1">Partnerships</h3>
                 <p class="text-gray-600 mb-2">Business partnerships and collaborations</p>
-                <a href="mailto:sewing@warpandweftdata.com" class="text-orange-600 hover:text-orange-700 font-medium">
-                  sewing@warpandweftdata.com
-                </a>
+                <a href="mailto:sewing@warpandweftdata.com" class="text-orange-600 hover:text-orange-700 font-medium">Email us</a>
               </div>
             </div>
           </div>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -214,7 +214,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-6">Ready to Transform Your Music?</h2>
       <p class="text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
-        Download JamBuddy today and experience real-time chord detection for your favorite instruments.
+        Join the open testing program on Google Play and experience real-time chord detection for your favorite instruments.
       </p>
       <div class="flex flex-wrap gap-4 justify-center">
         <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-gray-800 border border-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-700 transition-colors flex items-center">
@@ -231,7 +231,7 @@ import Layout from '../layouts/Layout.astro';
           Wear OS App
         </a>
       </div>
-      <p class="text-gray-400 mt-4">Free download • Android 8.0+ required</p>
+      <p class="text-gray-400 mt-4">Open testing on Google Play • Android 8.0+ required</p>
     </div>
   </section>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,12 +14,13 @@ import Layout from '../layouts/Layout.astro';
           Real-time
           <span class="text-yellow-300">Chord Detection</span>
         </h1>
-        <p class="text-xl md:text-2xl mb-8 text-gray-300 max-w-3xl mx-auto">
+        <p class="text-xl md:text-2xl mb-4 text-gray-300 max-w-3xl mx-auto">
           Uses your phone's microphone to instantly identify chords from any music - whether you're playing an instrument or listening to your favorite songs.
         </p>
+        <p class="text-lg text-yellow-300 mb-8">Open testing now available on Google Play.</p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
           <a href="#download" class="bg-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-600 transition-colors">
-            Download Free
+            Join Open Testing
           </a>
           <a href="/features" class="border-2 border-gray-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-800 hover:border-gray-500 transition-colors">
             See Features
@@ -172,7 +173,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-4xl font-bold mb-4">Ready to Jam?</h2>
       <p class="text-xl mb-8">
-        Download JamBuddy today and instantly identify chords in any music you hear.
+        Join our open testing program on Google Play and start identifying chords instantly.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-white/10 border border-white/30 backdrop-blur-sm text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-white/20 transition-colors flex items-center justify-center">
@@ -189,7 +190,7 @@ import Layout from '../layouts/Layout.astro';
           Get the Wear OS App
         </a>
       </div>
-      <p class="text-blue-200 mt-4">Free download • Android 8.0+ required</p>
+      <p class="text-blue-200 mt-4">Open testing on Google Play • Android 8.0+ required</p>
     </div>
   </section>
 </Layout>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -43,7 +43,6 @@ import Layout from '../layouts/Layout.astro';
         <p>If you have any questions about this Privacy Policy or our commitment to your privacy, please contact us at:</p>
         <div class="bg-gray-50 p-6 rounded-lg mt-4 max-w-md">
           <p><strong>Email:</strong> <a href="mailto:sewing@warpandweftdata.com" class="text-blue-600 hover:text-blue-700">sewing@warpandweftdata.com</a></p>
-          <p><strong>General Contact:</strong> <a href="mailto:sewing@warpandweftdata.com" class="text-blue-600 hover:text-blue-700">sewing@warpandweftdata.com</a></p>
           <p><strong>Address:</strong> Mountain Park, GA 30047</p>
         </div>
       </div>
@@ -55,10 +54,10 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">Ready to Get Started?</h2>
       <p class="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
-        Download JamBuddy today and enjoy a fully private musical experience.
+        Join our Google Play open testing and enjoy a fully private musical experience.
       </p>
-      <a href="#download" class="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors">
-        Download JamBuddy
+      <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors">
+        Join Open Testing
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- overhaul README with project info and instructions
- clarify hero text about open testing
- update About page CTA to join open testing
- update Privacy page CTA with new wording

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6849c3613df083289bf3068f3b5b0bd5