### PR TITLE
Add closed testing signup with GitHub issue backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@ This repository contains the marketing site for **JamBuddy**, a real-time chord 
 
 JamBuddy is currently available via open testing on Google Play. Visit the site to join the program and give feedback as development continues.
 
+## Closed Testing Signups
+
+Users can now request access to closed testing by submitting the form at
+`/closed-testing`. Submissions create GitHub issues using a Netlify serverless
+function. Deployments must configure the following environment variables:
+
+```
+GITHUB_TOKEN=<personal access token>
+GITHUB_REPO=stewing-co/jambuddy-live-website
+```
+
+Create a token under **Settings → Developer settings → Personal access tokens**
+("Tokens (classic)" or a fine-grained token) with at least the `public_repo`
+scope. Add this token to your Netlify project as `GITHUB_TOKEN` so the signup
+function can open issues on your behalf.
+
 ## Local Development
 
 ```bash

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,9 @@
 [build.environment]
   NODE_VERSION = "20"
 
+[functions]
+  directory = "netlify/functions"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/signup.js
+++ b/netlify/functions/signup.js
@@ -1,0 +1,47 @@
+export async function handler(event) {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: 'Method Not Allowed' };
+  }
+
+  let data;
+  try {
+    data = JSON.parse(event.body);
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON' };
+  }
+
+  const { name, email } = data;
+  if (!name || !email) {
+    return { statusCode: 400, body: 'Missing name or email' };
+  }
+
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPO || 'stewing-co/jambuddy-live-website';
+  if (!token || !repo) {
+    return { statusCode: 500, body: 'GitHub configuration missing' };
+  }
+
+  const issueTitle = `Closed testing signup: ${name}`;
+  const issueBody = `Email: ${email}\n\nUser expressed interest in closed testing.`;
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${token}`,
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ title: issueTitle, body: issueBody })
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      return { statusCode: 500, body: `GitHub API error: ${text}` };
+    }
+
+    return { statusCode: 200, body: 'Signup submitted' };
+  } catch (err) {
+    return { statusCode: 500, body: `Server error: ${err.message}` };
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,6 +30,7 @@ const { title, description = "JamBuddy - Real-time musical accompaniment and cho
           <div class="flex items-center space-x-8">
             <a href="/" class="text-gray-300 hover:text-white transition-colors">Home</a>
             <a href="/features" class="text-gray-300 hover:text-white transition-colors">Features</a>
+            <a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Testing</a>
             <a href="/about" class="text-gray-300 hover:text-white transition-colors">About</a>
             <a href="/contact" class="text-gray-300 hover:text-white transition-colors">Contact</a>
             <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-gray-800 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors">Google Play</a>
@@ -79,6 +80,7 @@ const { title, description = "JamBuddy - Real-time musical accompaniment and cho
             <h4 class="text-lg font-semibold mb-4">Company</h4>
             <ul class="space-y-2">
               <li><a href="/about" class="text-gray-300 hover:text-white transition-colors">About</a></li>
+              <li><a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Testing</a></li>
               <li><a href="/contact" class="text-gray-300 hover:text-white transition-colors">Contact</a></li>
               <li><a href="/privacy" class="text-gray-300 hover:text-white transition-colors">Privacy</a></li>
             </ul>

--- a/src/pages/closed-testing.astro
+++ b/src/pages/closed-testing.astro
@@ -1,0 +1,23 @@
+---
+import Layout from '../layouts/Layout.astro';
+---
+
+<Layout title="Closed Testing Signup - JamBuddy" description="Sign up for our closed testing program or join the mailing list for updates.">
+  <section class="bg-blue-900/90 text-white py-20 rounded-lg">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <h1 class="text-4xl md:text-5xl font-bold mb-6">Join Closed Testing</h1>
+      <p class="text-xl mb-8">Sign up below to request access to the closed testing program or to join our email list for future updates.</p>
+      <form id="signup-form" class="space-y-6 max-w-lg mx-auto" method="POST" action="/.netlify/functions/signup">
+        <div>
+          <label for="name" class="block text-left text-sm font-medium mb-2">Name</label>
+          <input type="text" id="name" name="name" required class="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900" />
+        </div>
+        <div>
+          <label for="email" class="block text-left text-sm font-medium mb-2">Email</label>
+          <input type="email" id="email" name="email" required class="w-full px-4 py-3 border border-gray-300 rounded-lg text-gray-900" />
+        </div>
+        <button type="submit" class="w-full bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold hover:bg-blue-700 transition-colors">Sign Up</button>
+      </form>
+    </div>
+  </section>
+</Layout>


### PR DESCRIPTION
## Summary
- add Netlify function to create GitHub issues for signups
- configure Netlify to use functions directory
- add Closed Testing page with signup form
- link Closed Testing in navigation and footer
- document environment variables required for signup
- default to `stewing-co/jambuddy-live-website` for issue creation
- clarify how to generate a GitHub token for signups

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684c21d38e208328b56b850ae5f0161f