### PR TITLE
Replace open testing with closed alpha testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This repository contains the marketing site for **JamBuddy**, a real-time chord detection app. The site is built with [Astro](https://astro.build/) and Tailwind CSS.
 
-JamBuddy is preparing for a closed testing release. Sign up for early access or join the mailing list for updates.
+JamBuddy is preparing for a closed alpha testing release. Sign up for early access or join the mailing list for updates.
 
-## Closed Testing Signups
+## Closed Alpha Testing Signups
 
-Users can now request access to closed testing by submitting the form at
+Users can now request access to closed alpha testing by submitting the form at
 `/closed-testing`. Submissions create GitHub issues using a Netlify serverless
 function. Deployments must configure the following environment variables:
 
@@ -24,9 +24,9 @@ scope and add it as `GITHUB_TOKEN`.
 The signup function uses these credentials to open issues in
 `stewing-co/jambuddy-live-website` for each signup.
 
-## Closed Testing Signups
+## Closed Alpha Testing Signups
 
-Users can now request access to closed testing by submitting the form at
+Users can now request access to closed alpha testing by submitting the form at
 `/closed-testing`. Submissions create GitHub issues using a Netlify serverless
 function. Deployments must configure the following environment variables:
 

--- a/netlify/functions/signup.js
+++ b/netlify/functions/signup.js
@@ -4,12 +4,14 @@ export async function handler(event) {
   }
 
   let data = {};
-  const contentType = event.headers['content-type'] || '';
+  const contentType = event.headers['content-type'] || event.headers['Content-Type'] || '';
   if (contentType.includes('application/json')) {
     try {
       data = JSON.parse(event.body);
     } catch {
-      return { statusCode: 400, body: 'Invalid JSON' };
+      const params = new URLSearchParams(event.body);
+      data.name = params.get('name');
+      data.email = params.get('email');
     }
   } else {
     const params = new URLSearchParams(event.body);
@@ -28,8 +30,8 @@ export async function handler(event) {
     return { statusCode: 500, body: 'GitHub configuration missing' };
   }
 
-  const issueTitle = `Closed testing signup: ${name}`;
-  const issueBody = `Email: ${email}\n\nUser expressed interest in closed testing.`;
+  const issueTitle = `Closed alpha testing signup: ${name}`;
+  const issueBody = `Email: ${email}\n\nUser expressed interest in closed alpha testing.`;
 
   try {
     const response = await fetch(`https://api.github.com/repos/${repo}/issues`, {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -30,7 +30,7 @@ const { title, description = "JamBuddy - Real-time musical accompaniment and cho
           <div class="flex items-center space-x-8">
             <a href="/" class="text-gray-300 hover:text-white transition-colors">Home</a>
             <a href="/features" class="text-gray-300 hover:text-white transition-colors">Features</a>
-            <a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Testing</a>
+            <a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Alpha Testing</a>
             <a href="/about" class="text-gray-300 hover:text-white transition-colors">About</a>
             <a href="/contact" class="text-gray-300 hover:text-white transition-colors">Contact</a>
             <a href="https://play.google.com/store/apps/details?id=com.jambuddy" class="bg-gray-800 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors">Google Play</a>
@@ -80,7 +80,7 @@ const { title, description = "JamBuddy - Real-time musical accompaniment and cho
             <h4 class="text-lg font-semibold mb-4">Company</h4>
             <ul class="space-y-2">
               <li><a href="/about" class="text-gray-300 hover:text-white transition-colors">About</a></li>
-              <li><a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Testing</a></li>
+              <li><a href="/closed-testing" class="text-gray-300 hover:text-white transition-colors">Closed Alpha Testing</a></li>
               <li><a href="/contact" class="text-gray-300 hover:text-white transition-colors">Contact</a></li>
               <li><a href="/privacy" class="text-gray-300 hover:text-white transition-colors">Privacy</a></li>
             </ul>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -195,16 +195,16 @@ import Layout from '../layouts/Layout.astro';
   <!-- CTA Section -->
   <section class="py-20 bg-black/80 rounded-lg mt-8">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">Join Closed Testing</h2>
+      <h2 class="text-3xl md:text-4xl font-bold text-white mb-6">Join Closed Alpha Testing</h2>
       <p class="text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
-        JamBuddy is still in development. Request access to the closed testing program and share your feedback!
+        JamBuddy is still in development. Request access to the closed alpha testing program and share your feedback!
       </p>
       <div class="flex flex-wrap gap-4 justify-center">
         <a href="/closed-testing" class="bg-gray-800 border border-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-700 transition-colors flex items-center">
           <svg class="w-6 h-6 mr-2" viewBox="0 0 24 24" fill="currentColor">
             <path d="M17.9,2.4c-0.1,0-0.2,0-0.2,0l-11,5l-3.8-3.8c-0.3-0.3-0.8-0.3-1.1,0s-0.3,0.8,0,1.1l3.2,3.2l-3.2,3.2 c-0.3,0.3-0.3,0.8,0,1.1c0.2,0.2,0.4,0.2,0.6,0.2c0.2,0,0.4-0.1,0.6-0.2l3.8-3.8l11,5c0.1,0,0.2,0.1,0.2,0.1c0.2,0,0.3-0.1,0.5-0.2 c0.2-0.2,0.3-0.4,0.3-0.7V3.3C18.8,2.8,18.4,2.4,17.9,2.4z"/>
           </svg>
-          Sign Up for Closed Testing
+          Sign Up for Closed Alpha Testing
         </a>
         <a href="/contact" class="bg-gray-800 border border-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-700 transition-colors flex items-center">
           <svg class="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/pages/closed-testing.astro
+++ b/src/pages/closed-testing.astro
@@ -2,11 +2,11 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Closed Testing Signup - JamBuddy" description="Sign up for our closed testing program or join the mailing list for updates.">
+<Layout title="Closed Alpha Testing Signup - JamBuddy" description="Sign up for our closed alpha testing program or join the mailing list for updates.">
   <section class="bg-blue-900/90 text-white py-20 rounded-lg">
     <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-      <h1 class="text-4xl md:text-5xl font-bold mb-6">Join Closed Testing</h1>
-      <p class="text-xl mb-8">Sign up below to request access to the closed testing program or to join our email list for future updates.</p>
+      <h1 class="text-4xl md:text-5xl font-bold mb-6">Join Closed Alpha Testing</h1>
+      <p class="text-xl mb-8">Sign up below to request access to the closed alpha testing program or to join our email list for future updates.</p>
       <form id="signup-form" class="space-y-6 max-w-lg mx-auto" method="POST" action="/.netlify/functions/signup">
         <div>
           <label for="name" class="block text-left text-sm font-medium mb-2">Name</label>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -214,10 +214,10 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-3xl md:text-4xl font-bold mb-6">Ready to Transform Your Music?</h2>
       <p class="text-xl text-gray-300 mb-8 max-w-2xl mx-auto">
-        Request early access to the closed testing program and experience real-time chord detection before launch.
+        Request early access to the closed alpha testing program and experience real-time chord detection before launch.
       </p>
       <a href="/closed-testing" class="bg-gray-800 border border-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-700 transition-colors inline-flex items-center">
-        Sign Up for Closed Testing
+        Sign Up for Closed Alpha Testing
       </a>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,10 +17,10 @@ import Layout from '../layouts/Layout.astro';
         <p class="text-xl md:text-2xl mb-4 text-gray-300 max-w-3xl mx-auto">
           Uses your phone's microphone to instantly identify chords from any music - whether you're playing an instrument or listening to your favorite songs.
         </p>
-        <p class="text-lg text-yellow-300 mb-8">Closed testing signups are open.</p>
+        <p class="text-lg text-yellow-300 mb-8">Closed alpha testing signups are open.</p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center">
           <a href="/closed-testing" class="bg-gray-700 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-600 transition-colors">
-            Sign Up for Closed Testing
+            Sign Up for Closed Alpha Testing
           </a>
           <a href="/features" class="border-2 border-gray-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-gray-800 hover:border-gray-500 transition-colors">
             See Features
@@ -173,10 +173,10 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-4xl font-bold mb-4">Ready to Jam?</h2>
       <p class="text-xl mb-8">
-        Request early access through our closed testing program and experience JamBuddy before launch.
+        Request early access through our closed alpha testing program and experience JamBuddy before launch.
       </p>
       <a href="/closed-testing" class="bg-white/10 border border-white/30 backdrop-blur-sm text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-white/20 transition-colors inline-flex items-center justify-center">
-        Sign Up for Closed Testing
+        Sign Up for Closed Alpha Testing
       </a>
     </div>
   </section>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -54,10 +54,10 @@ import Layout from '../layouts/Layout.astro';
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
       <h2 class="text-3xl md:text-4xl font-bold text-gray-900 mb-6">Ready to Get Started?</h2>
       <p class="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
-        Request early access via our closed testing program and enjoy a fully private musical experience.
+        Request early access via our closed alpha testing program and enjoy a fully private musical experience.
       </p>
       <a href="/closed-testing" class="bg-blue-600 text-white px-8 py-4 rounded-lg font-semibold text-lg hover:bg-blue-700 transition-colors">
-        Sign Up for Closed Testing
+        Sign Up for Closed Alpha Testing
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- update wording to call the program **closed alpha testing**
- handle incorrectly labeled form requests in signup function
- keep signups open on the closed alpha signup page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684c35beaea48328af7f68608e8bf058